### PR TITLE
TBS tooltip on editor menu, non-touch only

### DIFF
--- a/js/respond.Editor.js
+++ b/js/respond.Editor.js
@@ -2502,6 +2502,7 @@ respond.Editor.Build = function(el){
 	
 	// set HTML
   	$(el).html(response); 
+  	if (!head.touch) $('#editor-menu a').tooltip({container: 'body', placement: 'bottom'});
   	
   	if(respond.debug == true){
 	  	console.log('[respond.Editor] before SetupMenuEvents');


### PR DESCRIPTION
TBS tooltip called on editor menu items. Non-touch only due to the interpretation of hover as extra click.
