### PR TITLE
Updated publish process to always recompile LESS files when re-publishin...

### DIFF
--- a/libs/Publish.php
+++ b/libs/Publish.php
@@ -386,7 +386,7 @@ class Publish
 	    	$less = new lessc;
 
 	    	try{
-			  $less->checkedCompile($lessFile, $cssFile);
+			  $less->compileFile($lessFile, $cssFile);
 
 			  return true;
 			} 


### PR DESCRIPTION
Updated publish process to always recompile LESS files when re-publishing CSS (to correctly handle variables, etc.). 
Currently the publish does a checked compile so that if the file hasn't changed, it won't be recompiled. However, if a file does an import of the file that was just changed, then the file that is published will be skipped and the resulting CSS file will not reflect the expected changes. The only other way that you could guarantee that the resulting files correctly imported variables would be to do a grep (or equivalent) of the .less files to find ones that import others and to recompile those. However, that doesn't seem any more efficient.
