### PR TITLE
Corrected typo in contentType declaration of api objects. (The contentTy...

### DIFF
--- a/api/card.php
+++ b/api/card.php
@@ -40,7 +40,7 @@ class CardDefaultResource extends Tonic\Resource {
 	            
 	            // return a json response
 	            $response = new Tonic\Response(Tonic\Response::OK);
-	            $response->contentType = 'applicaton/json';
+	            $response->contentType = 'application/json';
 	            $response->body = json_encode($card_arr);
 	
 	            return $response;

--- a/api/category.php
+++ b/api/category.php
@@ -29,7 +29,7 @@ class CategoryAddResource extends Tonic\Resource {
          
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($category);
 
             return $response;
@@ -86,14 +86,14 @@ class CategoryListResource extends Tonic\Resource {
 	            
 	            // return a json response
 	            $response = new Tonic\Response(Tonic\Response::OK);
-	            $response->contentType = 'applicaton/json';
+	            $response->contentType = 'application/json';
 	            $response->body = json_encode($list);
 	
 	            return $response;
             }
             else{ // return an empty response (e.g. root has not categories)
 	            $response = new Tonic\Response(Tonic\Response::OK);
-	            $response->contentType = 'applicaton/json';
+	            $response->contentType = 'application/json';
 	            $response->body = '[]';
 	
 	            return $response;
@@ -131,7 +131,7 @@ class CategoryListPageResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($list);
 
             return $response;

--- a/api/customer.php
+++ b/api/customer.php
@@ -215,7 +215,7 @@ class CustomerGetResource extends Tonic\Resource {
 				}
 	
 			    $response = new Tonic\Response(Tonic\Response::OK);
-	            $response->contentType = 'applicaton/json';
+	            $response->contentType = 'application/json';
 	            $response->body = json_encode($customer);
 	
 	            return $response;

--- a/api/file.php
+++ b/api/file.php
@@ -70,7 +70,7 @@ class ImageListAllResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;
@@ -174,7 +174,7 @@ class FilePostResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;
@@ -276,7 +276,7 @@ class FileListAllResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;

--- a/api/layout.php
+++ b/api/layout.php
@@ -203,7 +203,7 @@ class LayoutListResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;

--- a/api/menuItem.php
+++ b/api/menuItem.php
@@ -32,7 +32,7 @@ class MenuItemAddResource extends Tonic\Resource {
          
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($menuItem);
 
             return $response;
@@ -65,7 +65,7 @@ class MenuItemListResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($list);
 
             return $response;

--- a/api/menuType.php
+++ b/api/menuType.php
@@ -25,7 +25,7 @@ class MenuTypeAddResource extends Tonic\Resource {
       
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($menuType);
 
             return $response;
@@ -83,7 +83,7 @@ class MenuTypeListAllResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($list);
 
             return $response;

--- a/api/page.php
+++ b/api/page.php
@@ -62,7 +62,7 @@ class PageAddResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($page);
 
             return $response;
@@ -101,7 +101,7 @@ class PageResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($page);
 
             return $response;
@@ -583,7 +583,7 @@ class PageListAll extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($pages);
 
             return $response;
@@ -725,7 +725,7 @@ class PageListSortedResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($pages);
 
             return $response;
@@ -817,7 +817,7 @@ class PageListFriendlyResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($pages);
 
             return $response;
@@ -969,7 +969,7 @@ class PageListResource extends Tonic\Resource {
 
         // return a json response
         $response = new Tonic\Response(Tonic\Response::OK);
-        $response->contentType = 'applicaton/json';
+        $response->contentType = 'application/json';
         $response->body = json_encode($pages);
 
         return $response;
@@ -1133,7 +1133,7 @@ class PageBlogResource extends Tonic\Resource {
 
         // return a json response
         $response = new Tonic\Response(Tonic\Response::OK);
-        $response->contentType = 'applicaton/json';
+        $response->contentType = 'application/json';
         $response->body = json_encode($pages);
 
         return $response;
@@ -1288,7 +1288,7 @@ class PageCalendarResource extends Tonic\Resource {
 
         // return a json response
         $response = new Tonic\Response(Tonic\Response::OK);
-        $response->contentType = 'applicaton/json';
+        $response->contentType = 'application/json';
         $response->body = json_encode($pages);
 
         return $response;
@@ -1393,7 +1393,7 @@ class PageTotalResource extends Tonic\Resource {
         
         // return a json response
         $response = new Tonic\Response(Tonic\Response::OK);
-        $response->contentType = 'applicaton/json';
+        $response->contentType = 'application/json';
         $response->body = $json;
 
         return $response;

--- a/api/pageType.php
+++ b/api/pageType.php
@@ -32,7 +32,7 @@ class PageTypeAddResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($pageType);
 
             return $response;
@@ -144,7 +144,7 @@ class PageTypeListAllResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($list);
 
             return $response;

--- a/api/plan.php
+++ b/api/plan.php
@@ -44,7 +44,7 @@ class PlanAddResource extends Tonic\Resource {
 		           
 		            // return a json response
 		            $response = new Tonic\Response(Tonic\Response::OK);
-		            $response->contentType = 'applicaton/json';
+		            $response->contentType = 'application/json';
 		            $response->body = json_encode($plan);
 		
 		            return $response;
@@ -175,7 +175,7 @@ class PlanListResource extends Tonic\Resource {
 				
 				// return a json response
 	            $response = new Tonic\Response(Tonic\Response::OK);
-	            $response->contentType = 'applicaton/json';
+	            $response->contentType = 'application/json';
 	            $response->body = json_encode($plans);
 	
 	            return $response;
@@ -248,7 +248,7 @@ class PlanGetResource extends Tonic\Resource {
 
 	            // return a json response
 	            $response = new Tonic\Response(Tonic\Response::OK);
-	            $response->contentType = 'applicaton/json';
+	            $response->contentType = 'application/json';
 	            $response->body = json_encode($plan);
 	
 	            return $response;

--- a/api/plugin.php
+++ b/api/plugin.php
@@ -22,7 +22,7 @@ class PluginResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = $json;
 
             return $response;

--- a/api/script.php
+++ b/api/script.php
@@ -208,7 +208,7 @@ class ScriptsListResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;

--- a/api/site.php
+++ b/api/site.php
@@ -444,7 +444,7 @@ class SiteCurrentResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($site);
 
             return $response;
@@ -596,7 +596,7 @@ class SiteResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($site);
 
             return $response;
@@ -703,7 +703,7 @@ class SiteListAllResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($list);
 
             return $response;
@@ -806,7 +806,7 @@ class SiteListExtendedResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($sites);
 
             return $response;

--- a/api/snippet.php
+++ b/api/snippet.php
@@ -208,7 +208,7 @@ class SnippetsListResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;

--- a/api/stylesheet.php
+++ b/api/stylesheet.php
@@ -205,7 +205,7 @@ class StylehseetListResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;

--- a/api/theme.php
+++ b/api/theme.php
@@ -65,7 +65,7 @@ class ThemeResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = $json;
 
             return $response;
@@ -244,7 +244,7 @@ class ThemePagesListResource extends Tonic\Resource {
             
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($arr);
 
             return $response;

--- a/api/transaction.php
+++ b/api/transaction.php
@@ -21,7 +21,7 @@ class TransactionListResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($list);
 
             return $response;

--- a/api/user.php
+++ b/api/user.php
@@ -34,7 +34,7 @@ class UserLoginResource extends Tonic\Resource {
 				
 				// return a json response
 	            $response = new Tonic\Response(Tonic\Response::OK);
-	            $response->contentType = 'applicaton/json';
+	            $response->contentType = 'application/json';
 	            $response->body = json_encode($params);
 			
 			}
@@ -176,7 +176,7 @@ class UserAddResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($user);
 
             return $response;
@@ -209,7 +209,7 @@ class UserCurrentResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($user);
 
             return $response;
@@ -249,7 +249,7 @@ class UserPhotoResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
 
             return $response;
         
@@ -281,7 +281,7 @@ class UserResource extends Tonic\Resource {
 
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($user);
 
             return $response;
@@ -373,7 +373,7 @@ class UserListAll extends Tonic\Resource {
       
             // return a json response
             $response = new Tonic\Response(Tonic\Response::OK);
-            $response->contentType = 'applicaton/json';
+            $response->contentType = 'application/json';
             $response->body = json_encode($list);
 
             return $response;


### PR DESCRIPTION
...pe being used was "applicaton/json", while the correct JSON MIME type is "application/json" [http://www.ietf.org/rfc/rfc4627.txt section 6]).
