### PR TITLE
pages marked as secure are no longer part of the generated sitemap.xml

### DIFF
--- a/libs/Utilities.php
+++ b/libs/Utilities.php
@@ -349,6 +349,10 @@ class Utilities
           
           $pageType = PageType::GetByPageTypeId($row['PageTypeId']);
           
+          if($pageType['IsSecure']==1) {
+          	continue;
+          }
+          
           if($row['PageTypeId']==-1){
             
             $xml = $xml.'<url>'.


### PR DESCRIPTION
This is a pull request to fix #152
