### PR TITLE
Fix freeze when adding users on systems without access to /dev/urandom

### DIFF
--- a/libs/PasswordHash.php
+++ b/libs/PasswordHash.php
@@ -48,7 +48,7 @@ class PasswordHash {
 	function get_random_bytes($count)
 	{
 		$output = '';
-		if (is_readable('/dev/urandom') &&
+		if (@is_readable('/dev/urandom') &&
 		    ($fh = @fopen('/dev/urandom', 'rb'))) {
 			$output = fread($fh, $count);
 			fclose($fh);


### PR DESCRIPTION
When one attempts to create a user on a system that is not able to access /dev/urandom (such as Media Temple dv servers that run all sites in chroot jails by default) the user is created successfully but a PHP warning causes the screen to hang, making it appear as if the operation never completed.  This commit suppresses the warning and fixes the issue.  I have also tested the change on a system that _is_ able to access /dev/urandom and it did not cause a problem.

It's not incredibly obvious at first glance, but if you look at the get_random_bytes() function closely you'll see that it does fully handle cases when /dev/urandom isn't accessible.  Full discussion here:  https://github.com/jenssegers/codeigniter-phpass-library/issues/1

P.S.  This is my very first pull request ever - did I do it right?  I figure it's better to start with one-character commits with big explanations, and then work my way up to big commits with one-character explanations.  Or maybe there's a happy medium somewhere in between :-)
