### PR TITLE
Remove http: prefix from font-links to provide better https support

### DIFF
--- a/app.php
+++ b/app.php
@@ -43,7 +43,7 @@
     }
     
 	// font library
-	define('FONT', 'http://fonts.googleapis.com/css?family=Roboto:400,700|Roboto+Condensed:400,700|Inconsolata');
+	define('FONT', '//fonts.googleapis.com/css?family=Roboto:400,700|Roboto+Condensed:400,700|Inconsolata');
 	
 	// bootsrap css libraries
 	define('BOOTSTRAP_CSS', '//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css');

--- a/themes/advanced/layouts/home.html
+++ b/themes/advanced/layouts/home.html
@@ -13,7 +13,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-<link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
+<link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
 
 {{css-bootstrap}}
 {{css}}

--- a/themes/advanced/layouts/post.html
+++ b/themes/advanced/layouts/post.html
@@ -13,7 +13,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-<link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
+<link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
 
 {{css-bootstrap}}
 {{css}}

--- a/themes/simple/layouts/home.html
+++ b/themes/simple/layouts/home.html
@@ -13,7 +13,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-<link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
+<link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
 
 {{css-bootstrap}}
 {{css}}

--- a/themes/simple/layouts/post.html
+++ b/themes/simple/layouts/post.html
@@ -13,7 +13,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-<link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
+<link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
 
 {{css-bootstrap}}
 {{css}}


### PR DESCRIPTION
It is necessary to remove http: in front of the link to the specific font

``` html
<link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">
```

for secured connections, because in secured connections are no unsecure contents allowed.
