### PR TITLE
Upgrade to FontAwesome 4.2.0 to restore plugin icon to editor toolbar

### DIFF
--- a/app.php
+++ b/app.php
@@ -68,7 +68,7 @@
 	
 	// js libraries
 	define('BOOTSTRAP_JS', '//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js');
-	define('FONTAWESOME_CSS', '//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css');
+	define('FONTAWESOME_CSS', '//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css');
 	define('JQUERY_JS', '//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js');
 	define('JQUERYUI_JS', '//code.jquery.com/ui/1.10.3/jquery-ui.js');
 	define('JQUERYUI_CSS', '//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css');

--- a/js/respond.Editor.js
+++ b/js/respond.Editor.js
@@ -145,7 +145,7 @@ respond.Editor.BuildMenu = function(el){
 				'<a class="html fa fa-html5 draggable" title="'+t('addhtml')+'" data-target="'+id+'"></a>' + 
 				'<a class="syntax fa fa-terminal draggable" title="'+t('addSyntax')+'" data-target="'+id+'"></a>' +
 				'<a class="secure fa fa-lock draggable" title="'+t('secure')+'" data-target="'+id+'"></a>' +
-				'<a class="plugins draggable" title="'+t('plugins')+'" data-target="'+id+'"></a>' +
+				'<a class="plugins fa fa-plug draggable" title="'+t('plugins')+'" data-target="'+id+'"></a>' +
 				'<span class="sep"></span>' +
 				'<a class="load fa fa-upload" title="'+t('load')+'" data-target="'+id+'"></a>' +
 				'<a class="layout fa fa-columns" title="'+t('layout')+'" data-target="'+id+'"></a>';


### PR DESCRIPTION
The plugin button in the editor toolbar was missing an icon.  I upgraded Font Awesome to 4.2.0, which includes a new fa-plug icon (http://fortawesome.github.io/Font-Awesome/icon/plug/) and added the necessary classes to the editor toolbar button.
