### PR TITLE
Load resources securely when available

### DIFF
--- a/js/helper/codemirror/doc/compress.html
+++ b/js/helper/codemirror/doc/compress.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: Compression Helper</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>
@@ -26,152 +26,152 @@
     click <strong>Compress</strong> to download the minified script
     file.</p>
 
-    <form id="form" action="http://marijnhaverbeke.nl/uglifyjs" method="post">
+    <form id="form" action="https://marijnhaverbeke.nl/uglifyjs" method="post">
       <input type="hidden" id="download" name="download" value="codemirror-compressed.js"/>
       <p>Version: <select id="version" onchange="setVersion(this);" style="padding: 1px">
-        <option value="http://codemirror.net/">HEAD</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.11;f=">3.11</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.1;f=">3.1</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.02;f=">3.02</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.01;f=">3.01</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.0;f=">3.0</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.38;f=">2.38</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.37;f=">2.37</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.36;f=">2.36</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.35;f=">2.35</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.34;f=">2.34</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.33;f=">2.33</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.32;f=">2.32</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.31;f=">2.31</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.3;f=">2.3</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.25;f=">2.25</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.24;f=">2.24</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.23;f=">2.23</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.22;f=">2.22</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.21;f=">2.21</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.2;f=">2.2</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.18;f=">2.18</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.16;f=">2.16</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.15;f=">2.15</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.13;f=">2.13</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.12;f=">2.12</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.11;f=">2.11</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.1;f=">2.1</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.02;f=">2.02</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.01;f=">2.01</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.0;f=">2.0</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=beta2;f=">beta2</option>
-        <option value="http://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=beta1;f=">beta1</option>
+        <option value="https://codemirror.net/">HEAD</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.11;f=">3.11</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.1;f=">3.1</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.02;f=">3.02</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.01;f=">3.01</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v3.0;f=">3.0</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.38;f=">2.38</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.37;f=">2.37</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.36;f=">2.36</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.35;f=">2.35</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.34;f=">2.34</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.33;f=">2.33</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.32;f=">2.32</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.31;f=">2.31</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.3;f=">2.3</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.25;f=">2.25</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.24;f=">2.24</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.23;f=">2.23</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.22;f=">2.22</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.21;f=">2.21</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.2;f=">2.2</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.18;f=">2.18</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.16;f=">2.16</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.15;f=">2.15</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.13;f=">2.13</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.12;f=">2.12</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.11;f=">2.11</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.1;f=">2.1</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.02;f=">2.02</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.01;f=">2.01</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=v2.0;f=">2.0</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=beta2;f=">beta2</option>
+        <option value="https://marijnhaverbeke.nl/git/codemirror?a=blob_plain;hb=beta1;f=">beta1</option>
       </select></p>
 
       <select multiple="multiple" size="20" name="code_url" style="width: 40em;" class="field" id="files">
         <optgroup label="CodeMirror Library">
-          <option value="http://codemirror.net/lib/codemirror.js" selected>codemirror.js</option>
+          <option value="https://codemirror.net/lib/codemirror.js" selected>codemirror.js</option>
         </optgroup>
         <optgroup label="Modes">
-          <option value="http://codemirror.net/mode/apl/apl.js">apl.js</option>
-          <option value="http://codemirror.net/mode/clike/clike.js">clike.js</option>
-          <option value="http://codemirror.net/mode/clojure/clojure.js">clojure.js</option>
-          <option value="http://codemirror.net/mode/coffeescript/coffeescript.js">coffeescript.js</option>
-          <option value="http://codemirror.net/mode/commonlisp/commonlisp.js">commonlisp.js</option>
-          <option value="http://codemirror.net/mode/css/css.js">css.js</option>
-          <option value="http://codemirror.net/mode/d/d.js">d.js</option>
-          <option value="http://codemirror.net/mode/diff/diff.js">diff.js</option>
-          <option value="http://codemirror.net/mode/ecl/ecl.js">ecl.js</option>
-          <option value="http://codemirror.net/mode/erlang/erlang.js">erlang.js</option>
-          <option value="http://codemirror.net/mode/gfm/gfm.js">gfm.js</option>
-          <option value="http://codemirror.net/mode/go/go.js">go.js</option>
-          <option value="http://codemirror.net/mode/groovy/groovy.js">groovy.js</option>
-          <option value="http://codemirror.net/mode/haskell/haskell.js">haskell.js</option>
-          <option value="http://codemirror.net/mode/haxe/haxe.js">haxe.js</option>
-          <option value="http://codemirror.net/mode/htmlembedded/htmlembedded.js">htmlembedded.js</option>
-          <option value="http://codemirror.net/mode/htmlmixed/htmlmixed.js">htmlmixed.js</option>
-          <option value="http://codemirror.net/mode/http/http.js">http.js</option>
-          <option value="http://codemirror.net/mode/javascript/javascript.js">javascript.js</option>
-          <option value="http://codemirror.net/mode/jinja2/jinja2.js">jinja2.js</option>
-          <option value="http://codemirror.net/mode/less/less.js">less.js</option>
-          <option value="http://codemirror.net/mode/livescript/livescript.js">livescript.js</option>
-          <option value="http://codemirror.net/mode/lua/lua.js">lua.js</option>
-          <option value="http://codemirror.net/mode/markdown/markdown.js">markdown.js</option>
-          <option value="http://codemirror.net/mode/mirc/mirc.js">mirc.js</option>
-          <option value="http://codemirror.net/mode/ntriples/ntriples.js">ntriples.js</option>
-          <option value="http://codemirror.net/mode/ocaml/ocaml.js">ocaml.js</option>
-          <option value="http://codemirror.net/mode/pascal/pascal.js">pascal.js</option>
-          <option value="http://codemirror.net/mode/perl/perl.js">perl.js</option>
-          <option value="http://codemirror.net/mode/php/php.js">php.js</option>
-          <option value="http://codemirror.net/mode/pig/pig.js">pig.js</option>
-          <option value="http://codemirror.net/mode/properties/properties.js">properties.js</option>
-          <option value="http://codemirror.net/mode/python/python.js">python.js</option>
-          <option value="http://codemirror.net/mode/q/q.js">q.js</option>
-          <option value="http://codemirror.net/mode/r/r.js">r.js</option>
-          <option value="http://codemirror.net/mode/rpm/changes/changes.js">rpm/changes.js</option>
-          <option value="http://codemirror.net/mode/rpm/spec/spec.js">rpm/spec.js</option>
-          <option value="http://codemirror.net/mode/rst/rst.js">rst.js</option>
-          <option value="http://codemirror.net/mode/ruby/ruby.js">ruby.js</option>
-          <option value="http://codemirror.net/mode/rust/rust.js">rust.js</option>
-          <option value="http://codemirror.net/mode/sass/sass.js">sass.js</option>
-          <option value="http://codemirror.net/mode/scala/scala.js">scala.js</option>
-          <option value="http://codemirror.net/mode/scheme/scheme.js">scheme.js</option>
-          <option value="http://codemirror.net/mode/shell/shell.js">shell.js</option>
-          <option value="http://codemirror.net/mode/sieve/sieve.js">sieve.js</option>
-          <option value="http://codemirror.net/mode/smalltalk/smalltalk.js">smalltalk.js</option>
-          <option value="http://codemirror.net/mode/smarty/smarty.js">smarty.js</option>
-          <option value="http://codemirror.net/mode/sql/sql.js">sql.js</option>
-          <option value="http://codemirror.net/mode/sparql/sparql.js">sparql.js</option>
-          <option value="http://codemirror.net/mode/stex/stex.js">stex.js</option>
-          <option value="http://codemirror.net/mode/tcl/tcl.js">tcl.js</option>
-          <option value="http://codemirror.net/mode/tiddlywiki/tiddlywiki.js">tiddlywiki.js</option>
-          <option value="http://codemirror.net/mode/tiki/tiki.js">tiki.js</option>
-          <option value="http://codemirror.net/mode/turtle/turtle.js">turtle.js</option>
-          <option value="http://codemirror.net/mode/vb/vb.js">vb.js</option>
-          <option value="http://codemirror.net/mode/vbscript/vbscript.js">vbscript.js</option>
-          <option value="http://codemirror.net/mode/velocity/velocity.js">velocity.js</option>
-          <option value="http://codemirror.net/mode/verilog/verilog.js">verilog.js</option>
-          <option value="http://codemirror.net/mode/xml/xml.js">xml.js</option>
-          <option value="http://codemirror.net/mode/xquery/xquery.js">xquery.js</option>
-          <option value="http://codemirror.net/mode/yaml/yaml.js">yaml.js</option>
-          <option value="http://codemirror.net/mode/z80/z80.js">z80.js</option>
+          <option value="https://codemirror.net/mode/apl/apl.js">apl.js</option>
+          <option value="https://codemirror.net/mode/clike/clike.js">clike.js</option>
+          <option value="https://codemirror.net/mode/clojure/clojure.js">clojure.js</option>
+          <option value="https://codemirror.net/mode/coffeescript/coffeescript.js">coffeescript.js</option>
+          <option value="https://codemirror.net/mode/commonlisp/commonlisp.js">commonlisp.js</option>
+          <option value="https://codemirror.net/mode/css/css.js">css.js</option>
+          <option value="https://codemirror.net/mode/d/d.js">d.js</option>
+          <option value="https://codemirror.net/mode/diff/diff.js">diff.js</option>
+          <option value="https://codemirror.net/mode/ecl/ecl.js">ecl.js</option>
+          <option value="https://codemirror.net/mode/erlang/erlang.js">erlang.js</option>
+          <option value="https://codemirror.net/mode/gfm/gfm.js">gfm.js</option>
+          <option value="https://codemirror.net/mode/go/go.js">go.js</option>
+          <option value="https://codemirror.net/mode/groovy/groovy.js">groovy.js</option>
+          <option value="https://codemirror.net/mode/haskell/haskell.js">haskell.js</option>
+          <option value="https://codemirror.net/mode/haxe/haxe.js">haxe.js</option>
+          <option value="https://codemirror.net/mode/htmlembedded/htmlembedded.js">htmlembedded.js</option>
+          <option value="https://codemirror.net/mode/htmlmixed/htmlmixed.js">htmlmixed.js</option>
+          <option value="https://codemirror.net/mode/http/http.js">http.js</option>
+          <option value="https://codemirror.net/mode/javascript/javascript.js">javascript.js</option>
+          <option value="https://codemirror.net/mode/jinja2/jinja2.js">jinja2.js</option>
+          <option value="https://codemirror.net/mode/less/less.js">less.js</option>
+          <option value="https://codemirror.net/mode/livescript/livescript.js">livescript.js</option>
+          <option value="https://codemirror.net/mode/lua/lua.js">lua.js</option>
+          <option value="https://codemirror.net/mode/markdown/markdown.js">markdown.js</option>
+          <option value="https://codemirror.net/mode/mirc/mirc.js">mirc.js</option>
+          <option value="https://codemirror.net/mode/ntriples/ntriples.js">ntriples.js</option>
+          <option value="https://codemirror.net/mode/ocaml/ocaml.js">ocaml.js</option>
+          <option value="https://codemirror.net/mode/pascal/pascal.js">pascal.js</option>
+          <option value="https://codemirror.net/mode/perl/perl.js">perl.js</option>
+          <option value="https://codemirror.net/mode/php/php.js">php.js</option>
+          <option value="https://codemirror.net/mode/pig/pig.js">pig.js</option>
+          <option value="https://codemirror.net/mode/properties/properties.js">properties.js</option>
+          <option value="https://codemirror.net/mode/python/python.js">python.js</option>
+          <option value="https://codemirror.net/mode/q/q.js">q.js</option>
+          <option value="https://codemirror.net/mode/r/r.js">r.js</option>
+          <option value="https://codemirror.net/mode/rpm/changes/changes.js">rpm/changes.js</option>
+          <option value="https://codemirror.net/mode/rpm/spec/spec.js">rpm/spec.js</option>
+          <option value="https://codemirror.net/mode/rst/rst.js">rst.js</option>
+          <option value="https://codemirror.net/mode/ruby/ruby.js">ruby.js</option>
+          <option value="https://codemirror.net/mode/rust/rust.js">rust.js</option>
+          <option value="https://codemirror.net/mode/sass/sass.js">sass.js</option>
+          <option value="https://codemirror.net/mode/scala/scala.js">scala.js</option>
+          <option value="https://codemirror.net/mode/scheme/scheme.js">scheme.js</option>
+          <option value="https://codemirror.net/mode/shell/shell.js">shell.js</option>
+          <option value="https://codemirror.net/mode/sieve/sieve.js">sieve.js</option>
+          <option value="https://codemirror.net/mode/smalltalk/smalltalk.js">smalltalk.js</option>
+          <option value="https://codemirror.net/mode/smarty/smarty.js">smarty.js</option>
+          <option value="https://codemirror.net/mode/sql/sql.js">sql.js</option>
+          <option value="https://codemirror.net/mode/sparql/sparql.js">sparql.js</option>
+          <option value="https://codemirror.net/mode/stex/stex.js">stex.js</option>
+          <option value="https://codemirror.net/mode/tcl/tcl.js">tcl.js</option>
+          <option value="https://codemirror.net/mode/tiddlywiki/tiddlywiki.js">tiddlywiki.js</option>
+          <option value="https://codemirror.net/mode/tiki/tiki.js">tiki.js</option>
+          <option value="https://codemirror.net/mode/turtle/turtle.js">turtle.js</option>
+          <option value="https://codemirror.net/mode/vb/vb.js">vb.js</option>
+          <option value="https://codemirror.net/mode/vbscript/vbscript.js">vbscript.js</option>
+          <option value="https://codemirror.net/mode/velocity/velocity.js">velocity.js</option>
+          <option value="https://codemirror.net/mode/verilog/verilog.js">verilog.js</option>
+          <option value="https://codemirror.net/mode/xml/xml.js">xml.js</option>
+          <option value="https://codemirror.net/mode/xquery/xquery.js">xquery.js</option>
+          <option value="https://codemirror.net/mode/yaml/yaml.js">yaml.js</option>
+          <option value="https://codemirror.net/mode/z80/z80.js">z80.js</option>
         </optgroup>
         <optgroup label="Add-ons">
-          <option value="http://codemirror.net/addon/dialog/dialog.js">dialog.js</option>
-          <option value="http://codemirror.net/addon/edit/closetag.js">closetag.js</option>
-          <option value="http://codemirror.net/addon/edit/continuecomment.js">continuecomment.js</option>
-          <option value="http://codemirror.net/addon/edit/continuelist.js">continuelist.js</option>
-          <option value="http://codemirror.net/addon/edit/matchbrackets.js">matchbrackets.js</option>
-          <option value="http://codemirror.net/addon/edit/closebrackets.js">closebrackets.js</option>
-          <option value="http://codemirror.net/addon/fold/foldcode.js">foldcode.js</option>
-          <option value="http://codemirror.net/addon/fold/xml-fold.js">xml-fold.js</option>
-          <option value="http://codemirror.net/addon/fold/brace-fold.js">brace-fold.js</option>
-          <option value="http://codemirror.net/addon/fold/indent-fold.js">indent-fold.js</option>
-          <option value="http://codemirror.net/addon/hint/javascript-hint.js">javascript-hint.js</option>
-          <option value="http://codemirror.net/addon/hint/xml-hint.js">xml-hint.js</option>
-          <option value="http://codemirror.net/addon/hint/html-hint.js">html-hint.js</option>
-          <option value="http://codemirror.net/addon/hint/pig-hint.js">pig-hint.js</option>
-          <option value="http://codemirror.net/addon/hint/python-hint.js">python-hint.js</option>
-          <option value="http://codemirror.net/addon/mode/loadmode.js">loadmode.js</option>
-          <option value="http://codemirror.net/addon/mode/overlay.js">overlay.js</option>
-          <option value="http://codemirror.net/addon/mode/multiplex.js">multiplex.js</option>
-          <option value="http://codemirror.net/addon/runmode/colorize.js">colorize.js</option>
-          <option value="http://codemirror.net/addon/runmode/runmode.js">runmode.js</option>
-          <option value="http://codemirror.net/addon/runmode/runmode-standalone.js">runmode-standalone.js</option>
-          <option value="http://codemirror.net/addon/runmode/runmode.node.js">runmode.node.js</option>
-          <option value="http://codemirror.net/addon/search/search.js">search.js</option>
-          <option value="http://codemirror.net/addon/search/searchcursor.js">searchcursor.js</option>
-          <option value="http://codemirror.net/addon/search/match-highlighter.js">match-highlighter.js</option>
-          <option value="http://codemirror.net/addon/selection/mark-selection.js">mark-selection.js</option>
-          <option value="http://codemirror.net/addon/selection/active-line.js">active-line.js</option>
-          <option value="http://codemirror.net/addon/lint/lint.js">lint.js</option>
-          <option value="http://codemirror.net/addon/lint/javascript-lint.js">javascript-lint.js</option>
-          <option value="http://codemirror.net/addon/lint/json-lint.js">json-lint.js</option>
+          <option value="https://codemirror.net/addon/dialog/dialog.js">dialog.js</option>
+          <option value="https://codemirror.net/addon/edit/closetag.js">closetag.js</option>
+          <option value="https://codemirror.net/addon/edit/continuecomment.js">continuecomment.js</option>
+          <option value="https://codemirror.net/addon/edit/continuelist.js">continuelist.js</option>
+          <option value="https://codemirror.net/addon/edit/matchbrackets.js">matchbrackets.js</option>
+          <option value="https://codemirror.net/addon/edit/closebrackets.js">closebrackets.js</option>
+          <option value="https://codemirror.net/addon/fold/foldcode.js">foldcode.js</option>
+          <option value="https://codemirror.net/addon/fold/xml-fold.js">xml-fold.js</option>
+          <option value="https://codemirror.net/addon/fold/brace-fold.js">brace-fold.js</option>
+          <option value="https://codemirror.net/addon/fold/indent-fold.js">indent-fold.js</option>
+          <option value="https://codemirror.net/addon/hint/javascript-hint.js">javascript-hint.js</option>
+          <option value="https://codemirror.net/addon/hint/xml-hint.js">xml-hint.js</option>
+          <option value="https://codemirror.net/addon/hint/html-hint.js">html-hint.js</option>
+          <option value="https://codemirror.net/addon/hint/pig-hint.js">pig-hint.js</option>
+          <option value="https://codemirror.net/addon/hint/python-hint.js">python-hint.js</option>
+          <option value="https://codemirror.net/addon/mode/loadmode.js">loadmode.js</option>
+          <option value="https://codemirror.net/addon/mode/overlay.js">overlay.js</option>
+          <option value="https://codemirror.net/addon/mode/multiplex.js">multiplex.js</option>
+          <option value="https://codemirror.net/addon/runmode/colorize.js">colorize.js</option>
+          <option value="https://codemirror.net/addon/runmode/runmode.js">runmode.js</option>
+          <option value="https://codemirror.net/addon/runmode/runmode-standalone.js">runmode-standalone.js</option>
+          <option value="https://codemirror.net/addon/runmode/runmode.node.js">runmode.node.js</option>
+          <option value="https://codemirror.net/addon/search/search.js">search.js</option>
+          <option value="https://codemirror.net/addon/search/searchcursor.js">searchcursor.js</option>
+          <option value="https://codemirror.net/addon/search/match-highlighter.js">match-highlighter.js</option>
+          <option value="https://codemirror.net/addon/selection/mark-selection.js">mark-selection.js</option>
+          <option value="https://codemirror.net/addon/selection/active-line.js">active-line.js</option>
+          <option value="https://codemirror.net/addon/lint/lint.js">lint.js</option>
+          <option value="https://codemirror.net/addon/lint/javascript-lint.js">javascript-lint.js</option>
+          <option value="https://codemirror.net/addon/lint/json-lint.js">json-lint.js</option>
         </optgroup>
         <optgroup label="Keymaps">
-          <option value="http://codemirror.net/keymap/emacs.js">emacs.js</option>
-          <option value="http://codemirror.net/keymap/vim.js">vim.js</option>
+          <option value="https://codemirror.net/keymap/emacs.js">emacs.js</option>
+          <option value="https://codemirror.net/keymap/vim.js">vim.js</option>
         </optgroup>
       </select></p>
 
       <p>
-        <button type="submit">Compress</button> with <a href="http://github.com/mishoo/UglifyJS/">UglifyJS</a>
+        <button type="submit">Compress</button> with <a href="https://github.com/mishoo/UglifyJS/">UglifyJS</a>
       </p>
 
       <p>Custom code to add to the compressed file:<textarea name="js_code" style="width: 100%; height: 15em;" class="field"></textarea></p>

--- a/js/helper/codemirror/doc/internals.html
+++ b/js/helper/codemirror/doc/internals.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: Internals</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
     <style>dl dl {margin: 0;} .update {color: #d40 !important}</style>
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>
@@ -32,11 +32,11 @@ version 2 was initially written. It no longer (even including the
 update at the bottom) fully represents the current implementation. I'm
 leaving it here as a historic document. For more up-to-date
 information, look at the entries
-tagged <a href="http://marijnhaverbeke.nl/blog/#cm-internals">cm-internals</a>
+tagged <a href="https://marijnhaverbeke.nl/blog/#cm-internals">cm-internals</a>
 on my blog.</p>
 
 <p>This is a followup to
-my <a href="http://codemirror.net/story.html">Brutal Odyssey to the
+my <a href="https://codemirror.net/story.html">Brutal Odyssey to the
 Dark Side of the DOM Tree</a> story. That one describes the
 mind-bending process of implementing (what would become) CodeMirror 1.
 This one describes the internals of CodeMirror 2, a complete rewrite
@@ -98,7 +98,7 @@ few dodgy features, I put the system in a vulnerable position—any
 incompatibility and bugginess in these features, I had to paper over
 with my own code. Not only did I have to do some serious stunt-work to
 get it to work on older browsers (as detailed in the
-previous <a href="http://codemirror.net/story.html">story</a>), things
+previous <a href="https://codemirror.net/story.html">story</a>), things
 also kept breaking in newly released versions, requiring me to come up
 with <em>new</em> scary hacks in order to keep up. This was starting
 to lose its appeal.</p>
@@ -278,7 +278,7 @@ single <code>innerHTML</code> update to do the refresh.</p>
 <h2 id="parse">Parsers can be Simple</h2>
 
 <p>When I wrote CodeMirror 1, I
-thought <a href="http://codemirror.net/story.html#parser">interruptable
+thought <a href="https://codemirror.net/story.html#parser">interruptable
 parsers</a> were a hugely scary and complicated thing, and I used a
 bunch of heavyweight abstractions to keep this supposed complexity
 under control: parsers

--- a/js/helper/codemirror/doc/manual.html
+++ b/js/helper/codemirror/doc/manual.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: User Manual</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
     <style>dl dl {margin: 0;}</style>
     <script src="../lib/codemirror.js"></script>
@@ -17,7 +17,7 @@
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>
@@ -127,7 +127,7 @@
       <dd>The mode to use. When not given, this will default to the
       first mode that was loaded. It may be a string, which either
       simply names the mode or is
-      a <a href="http://en.wikipedia.org/wiki/MIME">MIME</a> type
+      a <a href="https://en.wikipedia.org/wiki/MIME">MIME</a> type
       associated with the mode. Alternatively, it may be an object
       containing configuration options for the mode, with
       a <code>name</code> property that names the mode (for
@@ -1783,7 +1783,7 @@
 
     <p>It is possible, and encouraged, to associate your mode, or a
     certain configuration of your mode, with
-    a <a href="http://en.wikipedia.org/wiki/MIME">MIME</a> type. For
+    a <a href="https://en.wikipedia.org/wiki/MIME">MIME</a> type. For
     example, the JavaScript mode associates itself
     with <code>text/javascript</code>, and its JSON variant
     with <code>application/json</code>. To do this,

--- a/js/helper/codemirror/doc/modes.html
+++ b/js/helper/codemirror/doc/modes.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: Mode list</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>

--- a/js/helper/codemirror/doc/oldrelease.html
+++ b/js/helper/codemirror/doc/oldrelease.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
-    <link rel="alternate" href="http://twitter.com/statuses/user_timeline/242283288.rss" type="application/rss+xml"/>
+    <link rel="alternate" href="https://twitter.com/statuses/user_timeline/242283288.rss" type="application/rss+xml"/>
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>
@@ -19,7 +19,7 @@
 </pre>
 </div>
 
-  <p class="rel">22-10-2012: <a href="http://codemirror.net/codemirror-3.0beta2.zip">Version 3.0, beta 2</a>:</p>
+  <p class="rel">22-10-2012: <a href="https://codemirror.net/codemirror-3.0beta2.zip">Version 3.0, beta 2</a>:</p>
 
   <ul class="rel-note">
     <li>Fix page-based coordinate computation.</li>
@@ -35,7 +35,7 @@
     <li>Full <a href="https://github.com/marijnh/CodeMirror/compare/v3.0beta1...v3.0beta2">list of patches</a>.</li>
   </ul>
 
-  <p class="rel">19-09-2012: <a href="http://codemirror.net/codemirror-2.34.zip">Version 2.34</a>:</p>
+  <p class="rel">19-09-2012: <a href="https://codemirror.net/codemirror-2.34.zip">Version 2.34</a>:</p>
 
   <ul class="rel-note">
     <li>New mode: <a href="../mode/commonlisp/index.html">Common Lisp</a>.</li>
@@ -48,7 +48,7 @@
     <li><a href="https://github.com/marijnh/CodeMirror/compare/v2.33...v2.34">Full list</a> of patches.</li>
   </ul>
 
-  <p class="rel">19-09-2012: <a href="http://codemirror.net/codemirror-3.0beta1.zip">Version 3.0, beta 1</a>:</p>
+  <p class="rel">19-09-2012: <a href="https://codemirror.net/codemirror-3.0beta1.zip">Version 3.0, beta 1</a>:</p>
 
   <ul class="rel-note">
     <li>Bi-directional text support.</li>
@@ -58,7 +58,7 @@
     <li>Generalized event handling.</li>
   </ul>
 
-  <p class="rel">23-08-2012: <a href="http://codemirror.net/codemirror-2.33.zip">Version 2.33</a>:</p>
+  <p class="rel">23-08-2012: <a href="https://codemirror.net/codemirror-2.33.zip">Version 2.33</a>:</p>
 
   <ul class="rel-note">
     <li>New mode: <a href="../mode/sieve/index.html">Sieve</a>.</li>
@@ -72,13 +72,13 @@
     <li><a href="https://github.com/marijnh/CodeMirror/compare/v2.32...v2.33">Full list</a> of patches.</li>
   </ul>
 
-  <p class="rel">23-07-2012: <a href="http://codemirror.net/codemirror-2.32.zip">Version 2.32</a>:</p>
+  <p class="rel">23-07-2012: <a href="https://codemirror.net/codemirror-2.32.zip">Version 2.32</a>:</p>
 
   <p class="rel-note">Emergency fix for a bug where an editor with
   line wrapping on IE will break when there is <em>no</em>
   scrollbar.</p>
 
-  <p class="rel">20-07-2012: <a href="http://codemirror.net/codemirror-2.31.zip">Version 2.31</a>:</p>
+  <p class="rel">20-07-2012: <a href="https://codemirror.net/codemirror-2.31.zip">Version 2.31</a>:</p>
 
   <ul class="rel-note">
     <li>New modes: <a href="../mode/ocaml/index.html">OCaml</a>, <a href="../mode/haxe/index.html">Haxe</a>, and <a href="../mode/vb/index.html">VB.NET</a>.</li>
@@ -90,7 +90,7 @@
     <li>And more... <a href="https://github.com/marijnh/CodeMirror/compare/v2.3...v2.31">(all patches)</a></li>
   </ul>
 
-  <p class="rel">22-06-2012: <a href="http://codemirror.net/codemirror-2.3.zip">Version 2.3</a>:</p>
+  <p class="rel">22-06-2012: <a href="https://codemirror.net/codemirror-2.3.zip">Version 2.3</a>:</p>
 
   <ul class="rel-note">
     <li><strong>New scrollbar implementation</strong>. Should flicker less. Changes DOM structure of the editor.</li>
@@ -102,7 +102,7 @@
     <li>Lots of other <a href="https://github.com/marijnh/CodeMirror/compare/v2.25...v2.3">fixes</a>.</li>
   </ul>
 
-  <p class="rel">23-05-2012: <a href="http://codemirror.net/codemirror-2.25.zip">Version 2.25</a>:</p>
+  <p class="rel">23-05-2012: <a href="https://codemirror.net/codemirror-2.25.zip">Version 2.25</a>:</p>
 
   <ul class="rel-note">
     <li>New mode: <a href="../mode/erlang/index.html">Erlang</a>.</li>
@@ -113,7 +113,7 @@
     <li>Fix backspace and tab key repeat in Opera.</li>
   </ul>
 
-  <p class="rel">23-04-2012: <a href="http://codemirror.net/codemirror-2.24.zip">Version 2.24</a>:</p>
+  <p class="rel">23-04-2012: <a href="https://codemirror.net/codemirror-2.24.zip">Version 2.24</a>:</p>
 
   <ul class="rel-note">
     <li><strong>Drop support for Internet Explorer 6</strong>.</li>
@@ -132,7 +132,7 @@
     add <code>nofallthrough</code> boolean field instead.</li>
   </ul>
 
-  <p class="rel">26-03-2012: <a href="http://codemirror.net/codemirror-2.23.zip">Version 2.23</a>:</p>
+  <p class="rel">26-03-2012: <a href="https://codemirror.net/codemirror-2.23.zip">Version 2.23</a>:</p>
 
   <ul class="rel-note">
     <li>Change <strong>default binding for tab</strong> <a href="javascript:void(document.getElementById('tabbinding').style.display='')">[more]</a>
@@ -155,7 +155,7 @@
     <li>Add <a href="manual.html#findMarksAt"><code>findMarksAt</code></a> method.</li>
   </ul>
 
-  <p class="rel">27-02-2012: <a href="http://codemirror.net/codemirror-2.22.zip">Version 2.22</a>:</p>
+  <p class="rel">27-02-2012: <a href="https://codemirror.net/codemirror-2.22.zip">Version 2.22</a>:</p>
 
   <ul class="rel-note">
     <li>Allow <a href="manual.html#keymaps">key handlers</a> to pass up events, allow binding characters.</li>
@@ -168,7 +168,7 @@
     <li>Fix many bugs.</li>
   </ul>
 
-  <p class="rel">27-01-2012: <a href="http://codemirror.net/codemirror-2.21.zip">Version 2.21</a>:</p>
+  <p class="rel">27-01-2012: <a href="https://codemirror.net/codemirror-2.21.zip">Version 2.21</a>:</p>
 
   <ul class="rel-note">
     <li>Added <a href="../mode/less/index.html">LESS</a>, <a href="../mode/mysql/index.html">MySQL</a>,
@@ -183,7 +183,7 @@
     <li>Lots and lots of bugfixes.</li>
   </ul>
 
-  <p class="rel">20-12-2011: <a href="http://codemirror.net/codemirror-2.2.zip">Version 2.2</a>:</p>
+  <p class="rel">20-12-2011: <a href="https://codemirror.net/codemirror-2.2.zip">Version 2.2</a>:</p>
 
   <ul class="rel-note">
     <li>Slightly incompatible API changes. Read <a href="upgrade_v2.2.html">this</a>.</li>
@@ -206,10 +206,10 @@
     method.</li>
   </ul>
 
-  <p class="rel">21-11-2011: <a href="http://codemirror.net/codemirror-2.18.zip">Version 2.18</a>:</p>
+  <p class="rel">21-11-2011: <a href="https://codemirror.net/codemirror-2.18.zip">Version 2.18</a>:</p>
   <p class="rel-note">Fixes <code>TextMarker.clear</code>, which is broken in 2.17.</p>
 
-  <p class="rel">21-11-2011: <a href="http://codemirror.net/codemirror-2.17.zip">Version 2.17</a>:</p>
+  <p class="rel">21-11-2011: <a href="https://codemirror.net/codemirror-2.17.zip">Version 2.17</a>:</p>
   <ul class="rel-note">
     <li>Add support for <a href="manual.html#option_lineWrapping">line
     wrapping</a> and <a href="manual.html#hideLine">code
@@ -229,7 +229,7 @@
     <li>Various fixes to modes.</li>
   </ul>
 
-  <p class="rel">27-10-2011: <a href="http://codemirror.net/codemirror-2.16.zip">Version 2.16</a>:</p>
+  <p class="rel">27-10-2011: <a href="https://codemirror.net/codemirror-2.16.zip">Version 2.16</a>:</p>
   <ul class="rel-note">
     <li>Add <a href="../mode/perl/index.html">Perl</a>, <a href="../mode/rust/index.html">Rust</a>, <a href="../mode/tiddlywiki/index.html">TiddlyWiki</a>, and <a href="../mode/groovy/index.html">Groovy</a> modes.</li>
     <li>Dragging text inside the editor now moves, rather than copies.</li>
@@ -241,12 +241,12 @@
     <li>Fix editing code with tabs in Internet Explorer.</li>
   </ul>
 
-  <p class="rel">26-09-2011: <a href="http://codemirror.net/codemirror-2.15.zip">Version 2.15</a>:</p>
+  <p class="rel">26-09-2011: <a href="https://codemirror.net/codemirror-2.15.zip">Version 2.15</a>:</p>
   <p class="rel-note">Fix bug that snuck into 2.14: Clicking the
   character that currently has the cursor didn't re-focus the
   editor.</p>
 
-  <p class="rel">26-09-2011: <a href="http://codemirror.net/codemirror-2.14.zip">Version 2.14</a>:</p>
+  <p class="rel">26-09-2011: <a href="https://codemirror.net/codemirror-2.14.zip">Version 2.14</a>:</p>
   <ul class="rel-note">
     <li>Add <a href="../mode/clojure/index.html">Clojure</a>, <a href="../mode/pascal/index.html">Pascal</a>, <a href="../mode/ntriples/index.html">NTriples</a>, <a href="../mode/jinja2/index.html">Jinja2</a>, and <a href="../mode/markdown/index.html">Markdown</a> modes.</li>
     <li>Add <a href="../theme/cobalt.css">Cobalt</a> and <a href="../theme/eclipse.css">Eclipse</a> themes.</li>
@@ -257,7 +257,7 @@
   </ul>
 
 
-  <p class="rel">23-08-2011: <a href="http://codemirror.net/codemirror-2.13.zip">Version 2.13</a>:</p>
+  <p class="rel">23-08-2011: <a href="https://codemirror.net/codemirror-2.13.zip">Version 2.13</a>:</p>
   <ul class="rel-note">
     <li>Add <a href="../mode/ruby/index.html">Ruby</a>, <a href="../mode/r/index.html">R</a>, <a href="../mode/coffeescript/index.html">CoffeeScript</a>, and <a href="../mode/velocity/index.html">Velocity</a> modes.</li>
     <li>Add <a href="manual.html#getGutterElement"><code>getGutterElement</code></a> to API.</li>
@@ -266,7 +266,7 @@
     <li>Add an experimental <a href="../mode/xmlpure/index.html">pure XML</a> mode.</li>
   </ul>
 
-  <p class="rel">25-07-2011: <a href="http://codemirror.net/codemirror-2.12.zip">Version 2.12</a>:</p>
+  <p class="rel">25-07-2011: <a href="https://codemirror.net/codemirror-2.12.zip">Version 2.12</a>:</p>
   <ul class="rel-note">
     <li>Add a <a href="../mode/sparql/index.html">SPARQL</a> mode.</li>
     <li>Fix bug with cursor jumping around in an unfocused editor in IE.</li>
@@ -280,7 +280,7 @@
     <li>Fix width feedback loop bug that caused the width of an inner DIV to shrink.</li>
   </ul>
 
-  <p class="rel">04-07-2011: <a href="http://codemirror.net/codemirror-2.11.zip">Version 2.11</a>:</p>
+  <p class="rel">04-07-2011: <a href="https://codemirror.net/codemirror-2.11.zip">Version 2.11</a>:</p>
   <ul class="rel-note">
     <li>Add a <a href="../mode/scheme/index.html">Scheme mode</a>.</li>
     <li>Add a <code>replace</code> method to search cursors, for cursor-preserving replacements.</li>
@@ -293,14 +293,14 @@
     <li>Add <a href="../demo/fullscreen.html">full-screen editing</a> and <a href="../demo/changemode.html">mode-changing</a> demos.</li>
   </ul>
 
-  <p class="rel">07-06-2011: <a href="http://codemirror.net/codemirror-2.1.zip">Version 2.1</a>:</p>
+  <p class="rel">07-06-2011: <a href="https://codemirror.net/codemirror-2.1.zip">Version 2.1</a>:</p>
   <p class="rel-note">Add
   a <a href="manual.html#option_theme">theme</a> system
   (<a href="../demo/theme.html">demo</a>). Note that this is not
   backwards-compatible—you'll have to update your styles and
   modes!</p>
 
-  <p class="rel">07-06-2011: <a href="http://codemirror.net/codemirror-2.02.zip">Version 2.02</a>:</p>
+  <p class="rel">07-06-2011: <a href="https://codemirror.net/codemirror-2.02.zip">Version 2.02</a>:</p>
   <ul class="rel-note">
     <li>Add a <a href="../mode/lua/index.html">Lua mode</a>.</li>
     <li>Fix reverse-searching for a regexp.</li>
@@ -312,7 +312,7 @@
     <li>Fix problem with 'sticking' horizontal scrollbar.</li>
   </ul>
 
-  <p class="rel">26-05-2011: <a href="http://codemirror.net/codemirror-2.01.zip">Version 2.01</a>:</p>
+  <p class="rel">26-05-2011: <a href="https://codemirror.net/codemirror-2.01.zip">Version 2.01</a>:</p>
   <ul class="rel-note">
     <li>Add a <a href="../mode/smalltalk/index.html">Smalltalk mode</a>.</li>
     <li>Add a <a href="../mode/rst/index.html">reStructuredText mode</a>.</li>
@@ -330,14 +330,14 @@
     <li>Fix the context menu for Firefox.</li>
   </ul>
 
-  <p class="rel">28-03-2011: <a href="http://codemirror.net/codemirror-2.0.zip">Version 2.0</a>:</p>
+  <p class="rel">28-03-2011: <a href="https://codemirror.net/codemirror-2.0.zip">Version 2.0</a>:</p>
   <p class="rel-note">CodeMirror 2 is a complete rewrite that's
   faster, smaller, simpler to use, and less dependent on browser
   quirks. See <a href="internals.html">this</a>
-  and <a href="http://groups.google.com/group/codemirror/browse_thread/thread/5a8e894024a9f580">this</a>
+  and <a href="https://groups.google.com/group/codemirror/browse_thread/thread/5a8e894024a9f580">this</a>
   for more information.</a>
 
-  <p class="rel">28-03-2011: <a href="http://codemirror.net/codemirror-1.0.zip">Version 1.0</a>:</p>
+  <p class="rel">28-03-2011: <a href="https://codemirror.net/codemirror-1.0.zip">Version 1.0</a>:</p>
   <ul class="rel-note">
     <li>Fix error when debug history overflows.</li>
     <li>Refine handling of C# verbatim strings.</li>
@@ -347,18 +347,18 @@
   <p class="rel">22-02-2011: <a href="https://github.com/marijnh/codemirror/tree/beta2">Version 2.0 beta 2</a>:</p>
   <p class="rel-note">Somewhat more mature API, lots of bugs shaken out.</a>
 
-  <p class="rel">17-02-2011: <a href="http://codemirror.net/codemirror-0.94.zip">Version 0.94</a>:</p>
+  <p class="rel">17-02-2011: <a href="https://codemirror.net/codemirror-0.94.zip">Version 0.94</a>:</p>
   <ul class="rel-note">
     <li><code>tabMode: "spaces"</code> was modified slightly (now indents when something is selected).</li>
     <li>Fixes a bug that would cause the selection code to break on some IE versions.</li>
     <li>Disabling spell-check on WebKit browsers now works.</li>
   </ul>
 
-  <p class="rel">08-02-2011: <a href="http://codemirror.net/">Version 2.0 beta 1</a>:</p>
+  <p class="rel">08-02-2011: <a href="https://codemirror.net/">Version 2.0 beta 1</a>:</p>
   <p class="rel-note">CodeMirror 2 is a complete rewrite of
   CodeMirror, no longer depending on an editable frame.</p>
 
-  <p class="rel">19-01-2011: <a href="http://codemirror.net/codemirror-0.93.zip">Version 0.93</a>:</p>
+  <p class="rel">19-01-2011: <a href="https://codemirror.net/codemirror-0.93.zip">Version 0.93</a>:</p>
   <ul class="rel-note">
     <li>Added a <a href="contrib/regex/index.html">Regular Expression</a> parser.</li>
     <li>Fixes to the PHP parser.</li>
@@ -369,7 +369,7 @@
     <li>Fix yet another hang with line-numbering in hidden editors.</li>
   </ul>
 
-  <p class="rel">17-12-2010: <a href="http://codemirror.net/codemirror-0.92.zip">Version 0.92</a>:</p>
+  <p class="rel">17-12-2010: <a href="https://codemirror.net/codemirror-0.92.zip">Version 0.92</a>:</p>
   <ul class="rel-note">
     <li>Make CodeMirror work in XHTML documents.</li>
     <li>Fix bug in handling of backslashes in Python strings.</li>
@@ -383,7 +383,7 @@
   </ul>
 
   <p class="rel">11-11-2010: <a
-  href="http://codemirror.net/codemirror-0.91.zip">Version 0.91</a>:</p>
+  href="https://codemirror.net/codemirror-0.91.zip">Version 0.91</a>:</p>
   <ul class="rel-note">
     <li>Adds support for <a href="contrib/java">Java</a>.</li>
     <li>Small additions to the <a href="contrib/php">PHP</a> and <a href="contrib/sql">SQL</a> parsers.</li>
@@ -394,7 +394,7 @@
   </ul>
 
   <p class="rel">02-10-2010: <a
-  href="http://codemirror.net/codemirror-0.9.zip">Version 0.9</a>:</p>
+  href="https://codemirror.net/codemirror-0.9.zip">Version 0.9</a>:</p>
   <ul class="rel-note">
     <li>Add support for searching backwards.</li>
     <li>There are now parsers for <a href="contrib/scheme/index.html">Scheme</a>, <a href="contrib/xquery/index.html">XQuery</a>, and <a href="contrib/ometa/index.html">OmetaJS</a>.</li>
@@ -407,7 +407,7 @@
   </ul>
 
   <p class="rel">22-07-2010: <a
-  href="http://codemirror.net/codemirror-0.8.zip">Version 0.8</a>:</p>
+  href="https://codemirror.net/codemirror-0.8.zip">Version 0.8</a>:</p>
   <ul class="rel-note">
     <li>Add a <code>cursorCoords</code> method to find the screen
     coordinates of the cursor.</li>
@@ -430,7 +430,7 @@
   </ul>
 
   <p class="rel">27-04-2010: <a
-  href="http://codemirror.net/codemirror-0.67.zip">Version
+  href="https://codemirror.net/codemirror-0.67.zip">Version
   0.67</a>:</p>
   <p class="rel-note">More consistent page-up/page-down behaviour
   across browsers. Fix some issues with hidden editors looping forever
@@ -442,7 +442,7 @@
   running editor.</p>
 
   <p class="rel">01-03-2010: <a
-  href="http://codemirror.net/codemirror-0.66.zip">Version
+  href="https://codemirror.net/codemirror-0.66.zip">Version
   0.66</a>:</p>
   <p class="rel-note">Adds <code>removeLine</code> method to API.
   Introduces the <a href="contrib/plsql/index.html">PLSQL parser</a>.
@@ -451,7 +451,7 @@
   selection bugs, and a number of small glitches.</p>
 
   <p class="rel">12-11-2009: <a
-  href="http://codemirror.net/codemirror-0.65.zip">Version
+  href="https://codemirror.net/codemirror-0.65.zip">Version
   0.65</a>:</p>
   <p class="rel-note">Add support for having both line-wrapping and
   line-numbers turned on, make paren-highlighting style customisable
@@ -460,7 +460,7 @@
   <em>re</em>introduced in version 10.</p>
 
   <p class="rel">23-10-2009: <a
-  href="http://codemirror.net/codemirror-0.64.zip">Version
+  href="https://codemirror.net/codemirror-0.64.zip">Version
   0.64</a>:</p>
   <p class="rel-note">Solves some issues introduced by the
   paste-handling changes from the previous release. Adds
@@ -474,14 +474,14 @@
   browser incompatibilities.</p>
 
 <p class="rel"><em>31-08-2009</em>: <a
-href="http://codemirror.net/codemirror-0.63.zip">Version
+href="https://codemirror.net/codemirror-0.63.zip">Version
 0.63</a>:</p>
 <p class="rel-note"> Overhaul of paste-handling (less fragile), fixes for several
 serious IE8 issues (cursor jumping, end-of-document bugs) and a number
 of small problems.</p>
 
 <p class="rel"><em>30-05-2009</em>: <a
-href="http://codemirror.net/codemirror-0.62.zip">Version
+href="https://codemirror.net/codemirror-0.62.zip">Version
 0.62</a>:</p>
 <p class="rel-note">Introduces <a href="contrib/python/index.html">Python</a>
 and <a href="contrib/lua/index.html">Lua</a> parsers. Add

--- a/js/helper/codemirror/doc/realworld.html
+++ b/js/helper/codemirror/doc/realworld.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: Real-world uses</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>

--- a/js/helper/codemirror/doc/reporting.html
+++ b/js/helper/codemirror/doc/reporting.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: Reporting Bugs</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
     <style>li { margin-top: 1em; }</style>
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>

--- a/js/helper/codemirror/doc/upgrade_v2.2.html
+++ b/js/helper/codemirror/doc/upgrade_v2.2.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: Upgrading to v2.2</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>

--- a/js/helper/codemirror/doc/upgrade_v3.html
+++ b/js/helper/codemirror/doc/upgrade_v3.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <title>CodeMirror: Upgrading to v3</title>
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans:bold"/>
     <link rel="stylesheet" type="text/css" href="docs.css"/>
     <script src="../lib/codemirror.js"></script>
     <link rel="stylesheet" href="../lib/codemirror.css">
@@ -16,7 +16,7 @@
   </head>
   <body>
 
-<h1><span class="logo-braces">{ }</span> <a href="http://codemirror.net/">CodeMirror</a></h1>
+<h1><span class="logo-braces">{ }</span> <a href="https://codemirror.net/">CodeMirror</a></h1>
 
 <div class="grey">
 <img src="baboon.png" class="logo" alt="logo"/>

--- a/themes/advanced/layouts/home.html
+++ b/themes/advanced/layouts/home.html
@@ -13,7 +13,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-<link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
+<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
 
 {{css-bootstrap}}
 {{css}}

--- a/themes/advanced/layouts/post.html
+++ b/themes/advanced/layouts/post.html
@@ -13,7 +13,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-<link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
+<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">  
 
 {{css-bootstrap}}
 {{css}}


### PR DESCRIPTION
When loading font resources insecurely, browsers report that the site
loads resources over insecure connections.

Especially in "/themes/*/layouts/post.html" and "home.html", when
loading "http://fonts.googleapis.com/css?family=Open+Sans", this element
should be loaded securely so that browsers can safely report that all
elements on an SSL/TLS page are being loaded from secure sources.

Additionally, I searched through the rest of the code and changed
external links to HTTPS when the corresponding sites supported SSL.
I did check each site manually for SSL support. This second fix isn't really 
that important; it's mostly just good practice.

Side note: I noticed in "/js/helper/codemirror/doc/oldrelease.html" that there
was a twitter api call that no longer works, since twitter switched to their 
new api. Don't know if you want something to replace that, or what.
