### PR TITLE
Add indicators to image carousels

### DIFF
--- a/sites/common/modules/slideshow.php
+++ b/sites/common/modules/slideshow.php
@@ -6,6 +6,17 @@
 ?>
 
 <div id="<?php print $id; ?>" class="carousel slide">
+
+	<ol class="carousel-indicators">
+		<?php 
+		for( $i = 0; $i <= ( sizeof($imgHtml->find('img')) - 1); $i++ ) { 
+		?>
+			<li data-target="#<?php print $id; ?>" data-slide-to="<?php print $i; ?>"></li>
+		<?php
+		}
+		?>
+	</ol>
+
 	<div class="carousel-inner">
 		<?php 
 			if($imgHtml){


### PR DESCRIPTION
This commit adds support for standard Bootstrap indicators in image carousels.  Indicators are the pagination-style controls that indicate which slide is currently displayed and allow the user to switch between slides.  You can see them on this page, where they appear as small discs:  http://getbootstrap.com/examples/carousel/  This is also how they will appear in Respond once this patch is applied.

This change has been tested in the Simple and Advanced themes.  No changes are needed to those themes.
