### PR TITLE
Open newly-created site link in new browser tab

### DIFF
--- a/templates/create.html
+++ b/templates/create.html
@@ -539,7 +539,7 @@
 		
 		<p>
 			{{'view_site_here' | i18next}} <br>
-			<a id="siteLink" href="{{siteLink}}">{{siteLink}}</a>
+			<a id="siteLink" href="{{siteLink}}" target="_blank">{{siteLink}}</a>
 		</p>
 		
 		<p>


### PR DESCRIPTION
Upon creation of a new site, the user is presented with two links: one to edit his new site, and another to view his new site.  If the user clicks the link to view the new site first and then clicks the Back button, he is prompted to create a new site and the link to edit his site is gone forever.  I did have one user encounter this already, and he found it confusing.

I have added target="_blank" to open the second link in a new tab.  I like to use that sparingly, but in this case I think it might make sense, since the Back button isn't functional.  

A more proper solution might be to send the user to a new URL upon completion (ex: /created).  That's currently beyond my capabilities, although I'm starting to grok a tiny bit of Angular, so maybe someday I could pull it off.

I won't be heartbroken if you don't accept this pull request.  It's more of a suggestion than anything.