### PR TITLE
Added rule to map 404 errors the 404 page

### DIFF
--- a/api/libs/Publish.php
+++ b/api/libs/Publish.php
@@ -111,6 +111,7 @@ class Publish
 				'RewriteEngine On'.PHP_EOL.
 				'RewriteCond %{REQUEST_FILENAME} !-f'.PHP_EOL.
 				'RewriteRule ^([^\.]+)$ $1.html [NC,L]'.PHP_EOL.
+				'ErrorDocument 404 /page/error'.PHP_EOL.
 				'</IfModule>'.PHP_EOL.
 				'<IfModule mod_expires.c>'.PHP_EOL.
 				'ExpiresActive On '.PHP_EOL.


### PR DESCRIPTION
This could probably be made into a setting so that it could be remapped from the UI but this at least makes the default 404 page that comes with the template more usable.