### PR TITLE
Put composer.json in the top-level directory.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "vendor-dir": "api/vendor"
+    },
     "require": {
     	"phpmailer/phpmailer": "5.2.8",
     	"peej/tonic": "3.2",


### PR DESCRIPTION
It still needs to write the vendor folder in api/, but at least we do
not need to move to api/ to build the project.