### PR TITLE
Make passcode from setup.php available to Angular

### DIFF
--- a/api/setup.js.php
+++ b/api/setup.js.php
@@ -75,6 +75,9 @@ angular.module('respond.setup', [])
 	
 	// app
 	systemMessage:			'<?php print $system_message; ?>',
-	urlMode:			 	'<?php print URL_MODE; ?>'
+	urlMode:			 	'<?php print URL_MODE; ?>',
+
+	// passcode
+	passcode:			 	'<?php print PASSCODE; ?>'
 	
 });


### PR DESCRIPTION
The passcode field still appears on the "create site" form, even when the passcode is set to empty in setup.local.php.  It's happening because the passcode is not passed to Angular.  This fixes it.