### PR TITLE
Aligned Theme Editing Controls

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -758,9 +758,8 @@ body.content{}
 	}
 	
 	body .context-menu .form-group .sp-replacer{
-		position: absolute;
-		top: 0;
-		right: 0;
+		position: relative;
+		margin-left: 10px;
 		border: 1px solid #ddd;
 		background-color: #fff;
 		border-left: 1px solid transparent;
@@ -772,10 +771,8 @@ body.content{}
 		}
 	
 	body .context-menu .form-group .image-picker{
-		position: absolute;
-		top: 0;
-		right: 0;
-		margin: 0;
+		position: relative;
+		margin-left: 10px;
 		padding: 0;
 		width: 35px;
 		height: 30px;


### PR DESCRIPTION
Aligned the theme editing controls (color picker box, image selector box) with their respective textboxes instead of the control labels.

Before:
![before](https://cloud.githubusercontent.com/assets/10872878/7794469/a0291c0c-027f-11e5-9df3-6ac134b3e83c.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/10872878/7794477/a9500e4e-027f-11e5-9a0b-520a31b567c1.PNG)
