### PR TITLE
Use setup.php email address for From: line of site emails

### DIFF
--- a/api/libs/Utilities.php
+++ b/api/libs/Utilities.php
@@ -368,8 +368,9 @@ class Utilities
 			
 		}
 		
-		$mail->From = $from;
-		$mail->FromName = $fromName;
+		$mail->addReplyTo($from, $fromName); 		// Set Reply-To: header to the primary site email
+		$mail->From = EMAILS_FROM; 					// Set From: header to address specified in setup.php
+		$mail->FromName = EMAILS_FROM_NAME;
 		$mail->addAddress($to, '');
 		$mail->isHTML(true);
 		
@@ -410,8 +411,6 @@ class Utilities
 		$mail->Subject = $subject;
 		$mail->Body    = html_entity_decode($content, ENT_COMPAT, 'UTF-8');
 		
-		echo 'send email';
-    
 		if(!$mail->send()) {
 		   return true;
 		}

--- a/api/rest/site.php
+++ b/api/rest/site.php
@@ -256,8 +256,8 @@ class SiteCreateResource extends Tonic\Resource {
     		if(SEND_WELCOME_EMAIL == true && $email != ''){
     		
 	    		$to = $email;
-	    		$from = REPLY_TO;
-	    		$fromName = REPLY_TO_NAME;
+	    		$from = EMAILS_FROM;
+	    		$fromName = EMAILS_FROM_NAME;
 	    		$subject = WELCOME_EMAIL_SUBJECT;
 	    		$file = WELCOME_EMAIL_FILE;
 	    		
@@ -268,7 +268,7 @@ class SiteCreateResource extends Tonic\Resource {
 	    		$replace = array(
 	    			'{{brand-logo}}' => '<img src="'.BRAND_LOGO.'" style="max-height:50px">',
 	    			'{{brand}}' => BRAND,
-	    			'{{reply-to}}' => REPLY_TO,
+	    			'{{reply-to}}' => EMAILS_FROM,
 	    			'{{new-site-url}}' => $newSiteUrl,
 	    			'{{login-url}}' => $loginUrl
 	    		);

--- a/api/rest/user.php
+++ b/api/rest/user.php
@@ -221,8 +221,8 @@ class UserForgotResource extends Tonic\Resource {
             
             // send email
             $to = $email;
-    		$from = REPLY_TO;
-    		$fromName = REPLY_TO_NAME;
+    		$from = EMAILS_FROM;
+    		$fromName = EMAILS_FROM_NAME;
     		$subject = BRAND.': Reset Password';
     		$file = APP_LOCATION.'/emails/reset-password.html';
     		
@@ -231,7 +231,7 @@ class UserForgotResource extends Tonic\Resource {
     		
     		$replace = array(
     			'{{brand}}' => BRAND,
-    			'{{reply-to}}' => REPLY_TO,
+    			'{{reply-to}}' => EMAILS_FROM,
     			'{{reset-url}}' => $resetUrl
     		);
     		

--- a/setup.php
+++ b/setup.php
@@ -148,9 +148,9 @@
 	// Key used to encrypt site SMTP passwords
 	define('SMTPENC_KEY', 'iloverespond');
 	    
-    // Set what emails should be sent out and a reply-to email address
-	define('REPLY_TO', '');
-	define('REPLY_TO_NAME', '');
+    // Set the From: address and name for outgoing emails
+	define('EMAILS_FROM', '');
+	define('EMAILS_FROM_NAME', '');
 	
 	// Welcome email
 	define('SEND_WELCOME_EMAIL', true);


### PR DESCRIPTION
As discussed on the mailing list, Respond currently spoofs the From: line for the notification emails that are sent to site owners whenever a form is submitted on their site.  (The site's Primary Email address is used in both the to: and from: fields.)  That can lead to showstopping deliverability issues.

This changes that behavior, so it will instead use the From: address specified in setup.php.  It also sets the Reply-To: address to the site's Primary Email, so that when someone hits reply it won't be routed back to Respond admin's email address.  

This change will require action to be taken when upgrading from previous versions, so I suggest adding the following to the upgrade instructions:

- In setup.php, rename REPLY_TO to EMAILS_FROM
- In setup.php, rename REPLY_TO_NAME to EMAILS_FROM_NAME

I realize that renaming these constants makes upgrading a bit more difficult, but ultimately I think it makes the code clearer.  There were instances of $reply_to and REPLY_TO within the same function, and they were referring to two different things.  I also think the new name makes it easier to understand the purpose of those constants when installing Respond for the first time.

As always, I'm open to suggestions on better approaches.