### PR TITLE
Fixes render="publish" does not work when used with an expression

### DIFF
--- a/api/libs/Publish.php
+++ b/api/libs/Publish.php
@@ -1245,6 +1245,7 @@ class Publish
 			if(isset($el->url)){
 			
 				$url = $el->url;
+				$url = Publish::ApplyMustacheSyntax($url, $site, $page);
 				
 				// replace the / with a period
 				$url = str_replace('/', '.', $url);


### PR DESCRIPTION
based url #354.  This is handy for rendering the main content of a page to get better SEO love.