### PR TITLE
Update respond.editor.js

### DIFF
--- a/js/respond.editor.js
+++ b/js/respond.editor.js
@@ -536,7 +536,7 @@ respond.editor.setupMenuEvents = function(){
 	$(document).unbind('mousedown touchstart');
    
     // setup text events
-	$(document).on('mousedown touchstart', '.context-menu a', function(e){
+	$(document).on('mousedown touchstart', '.context-menu a :not(.plugin-remove)', function(e){
 		var action = $(this).attr('data-action') + '.create';
 		utilities.executeFunctionByName(action, window);
 		


### PR DESCRIPTION
Currently, when removing an image element from a block, an error message appears in the console:

     Uncaught TypeError: Cannot read property 'create' of undefined

Adding this pseudo-class eliminates the error.