### PR TITLE
Add support for LDAP authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,7 @@ PASSCODE=iloverespond
 ALLOWED_FILETYPES=jpg,png,gif,pdf
 THUMB_MAX_WIDTH=400
 THUMB_MAX_HEIGHT=400
+
+# ldap settings
+#LDAP_SERVER=domain.ex
+#LDAP_DOMAIN=yourdomain

--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -279,7 +279,8 @@ return response($css)->header('Content-Type', 'text/css');
       'logoUrl' => env('LOGO_URL'),
       'themesLocation' => env('THEMES_LOCATION'),
       'primaryColor' => env('PRIMARY_COLOR'),
-      'primaryDarkColor' => env('PRIMARY_DARK_COLOR')
+      'primaryDarkColor' => env('PRIMARY_DARK_COLOR'),
+      'usesLDAP' => !empty(env('LDAP_SERVER'))
     );
 
     return response()->json($settings);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -38,7 +38,20 @@ class UserController extends Controller
     if ($site != NULL) {
 
       // get the user from the credentials
-      $user = User::getByEmailPassword($email, $password, $site->id);
+      $user = NULL;
+
+      // if LDAP is being used, check for @ to determine how to authenticate user
+      if(strpos($email, '@') === false && !empty(env('LDAP_SERVER'))){
+        //authenticate against LDAP, on success get user by 'email'
+        $ldap = ldap_connect(env('LDAP_SERVER'));
+        if($bind = ldap_bind($ldap, env('LDAP_DOMAIN') . '\\' . $email)) {
+          $user = User::getByEmail($email, $site->id);
+        }
+      }
+      else {
+        // get the user from the credentials
+        $user = User::getByEmailPassword($email, $password, $site->id);
+      }
 
       if($user != NULL) {
 

--- a/public/src/login/login.component.html
+++ b/public/src/login/login.component.html
@@ -2,7 +2,8 @@
 
 <form class="app-form standalone" (submit)="login($event, email.value, password.value)">
 
-    <label>{{ 'Email' | translate }}</label>
+    <label *ngIf="usesLDAP === false">{{ 'Email' | translate }}</label>
+    <label *ngIf="usesLDAP === true">{{ 'Username' | translate }}</label>
     <input type="text" name="email" #email>
 
     <label>{{ 'Password' | translate }}</label>

--- a/public/src/login/login.component.ts
+++ b/public/src/login/login.component.ts
@@ -17,7 +17,8 @@ export class LoginComponent {
   data;
   id;
   errorMessage;
-  logoUrl;
+  logoUrl
+  usesLDAP = false;
 
   constructor (private _userService: UserService, private _appService: AppService, private _route: ActivatedRoute, private _router: Router, private _translate: TranslateService) {}
 
@@ -45,6 +46,7 @@ export class LoginComponent {
                      .subscribe(
                        data => {
                          this.logoUrl = data.logoUrl;
+                         this.usesLDAP = data.usesLDAP;
                        },
                        error =>  { this.failure(<any>error); }
                       );

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Status: 6 Stable, Maintenance Release 1
 - Desktop focused, mobile ready
 - Intuitive editing experience
 - Quick access to common customizations (forms, galleries, etc.)
+- LDAP authentication
 
 ### Developer features
 - Easy to write plugins


### PR DESCRIPTION
Adds support for LDAP authentication by setting LDAP_SERVER and LDAP_DOMAIN in the .env file. When LDAP authentication is enabled, the text for the email field on the login page with change from 'Email' to 'Username'