### PR TITLE
Add support for webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ SITE_URL=autodetect
 FRIENDLY_URLS=false
 THEMES_LOCATION=themes/
 TIMEZONE=America/Chicago
+WEBHOOKS_URL=
 
 # email setup
 EMAILS_FROM=sample@sample.com

--- a/app/Respond/Libraries/Webhooks.php
+++ b/app/Respond/Libraries/Webhooks.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Respond\Libraries;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use Log;
+
+class Webhooks
+{
+
+  /**
+   * Wrapper to send a webhook for a new site
+   *
+   * @param {Site} $site
+   * @return void
+   */
+	public static function NewSite($site){
+
+    Webhooks::SendWebhook( 'Site.New', $site );
+
+	}
+
+  /**
+   * Wrapper to send a webhook for a new user
+   *
+   * @param {User} $user
+   * @return void
+   */
+	public static function NewUser($user){
+
+    // Don't send the password, even if it is hashed
+    unset( $user->password );
+
+    Webhooks::SendWebhook( 'User.New', $user );
+
+	}
+
+  /**
+   * Wrapper to send a webhook for a form submission
+   *
+   * @param {Form} $form
+   * @return void
+   */
+	public static function FormSubmit($form){
+
+    Webhooks::SendWebhook( 'Form.Submit', $form );
+
+	}
+
+  /**
+   * Sends a webhook POST request. Silently logs error on failure.
+   *
+   * @param {Form} $form
+   * @return void
+   */
+  public static function SendWebhook($action,$data) {
+
+    if(env('WEBHOOKS_URL') != ''){
+
+			$client = new Client();
+
+      $request = array(
+        'headers' => array('X-Action' => $action),
+        'json' => $data
+      );
+
+      try {
+          $response = $client->post(env('WEBHOOKS_URL'), $request);
+      } catch (\GuzzleHttp\Exception\ClientException $e) {
+        Log::error('Unable to send ' . $action . ' webhook. Remote server responded with HTTP status code ' . $e->getResponse()->getStatusCode() . ': ' . $e->getResponse()->getReasonPhrase() );
+      } catch (\GuzzleHttp\Exception\RequestException $e) {
+        Log::error('Unable to send ' . $action . ' webhook. Remote server responded with ' . $e->getMessage() );
+      }
+
+		}
+
+  }
+
+}

--- a/app/Respond/Models/Site.php
+++ b/app/Respond/Models/Site.php
@@ -3,8 +3,8 @@
 namespace App\Respond\Models;
 
 use App\Respond\Libraries\Utilities;
-
 use App\Respond\Libraries\Publish;
+use App\Respond\Libraries\Webhooks;
 
 /**
  * Models a site
@@ -172,6 +172,9 @@ class Site {
     // create and save the site
   	$site = new Site($site_arr);
   	$site->save();
+
+    // send new site hook
+    Webhooks::NewSite($site);
 
     // create and save the user
     $user = new User(array(

--- a/app/Respond/Models/User.php
+++ b/app/Respond/Models/User.php
@@ -3,7 +3,9 @@
 namespace App\Respond\Models;
 
 use App\Respond\Models\Site;
+
 use App\Respond\Libraries\Utilities;
+use App\Respond\Libraries\Webhooks;
 
 /**
  * Models a user
@@ -140,7 +142,7 @@ class User {
    * Saves a user
    *
    * @param {string} $id the ID of the site
-   * @return {Site}
+   * @return void
    */
   public function save($id) {
 
@@ -177,11 +179,17 @@ class User {
     // save users
     $json = json_encode($users, JSON_PRETTY_PRINT);
 
-    // save site.json
+    // save users.json
     Utilities::saveContent($dir, 'users.json', $json);
 
-    return;
+    // Assemble data for webhook
+    $wh_data = clone $this;
+    $wh_data->siteId = $id;
 
+    // send new user hook
+    Webhooks::NewUser($wh_data);
+
+    return;
   }
 
   /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -23,7 +23,7 @@ $app = new Laravel\Lumen\Application(
     realpath(__DIR__.'/../')
 );
 
-// $app->withFacades();
+$app->withFacades();
 
 // $app->withEloquent();
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "sunra/php-simple-html-dom-parser": "1.5.1",
     "symfony/yaml": "3.0.3",
     "lullabot/amp": "1.0.7",
-    "alchemy/zippy": "^0.4.4"
+    "alchemy/zippy": "^0.4.4",
+    "guzzlehttp/guzzle": "^6.2.3"
   },
   "require-dev": {
   },


### PR DESCRIPTION
This adds support for POSTing JSON data to a webhook URL when sites are created, users are created, and forms are submitted - just like in Respond 5, except that some of the data fields are formatted a slight bit differently due to schema differences in R6.  

I am submitting as a PR so you can decide whether you want to include it.  I tested it pretty thoroughly and am confident that it works well.