### PR TITLE
Apply layout properties to .block instead of .row

### DIFF
--- a/app/Http/Controllers/EditController.php
+++ b/app/Http/Controllers/EditController.php
@@ -188,7 +188,7 @@ class EditController extends Controller
 
               // set block elements
               if($blocks === NULL) {
-                $blocks = '.row';
+                $blocks = '.block';
               }
 
               // find body element


### PR DESCRIPTION
This pull request is intend to work in concert with the one submitted to the respond-ui repo, at https://github.com/madoublet/respond-ui/pull/10 .  This particular change makes it so that changes to layout properties in the left-column admin panel such as id, class, background image, etc. are applied to the block div rather than the row one.  See the other PR for more details.